### PR TITLE
correctly dispose rootDisposable

### DIFF
--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinCompiler.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinCompiler.kt
@@ -40,6 +40,7 @@ import org.jetbrains.kotlin.script.KotlinScriptExtraImport
 import org.jetbrains.kotlin.utils.PathUtil
 
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer.newDisposable
 
 import org.slf4j.Logger
@@ -62,7 +63,7 @@ fun compileKotlinScript(scriptFile: File, scriptDef: KotlinScriptDefinition, cla
 
         throw IllegalStateException("Internal error: ${OutputMessageUtil.renderException(ex)}")
     } finally {
-        rootDisposable.dispose()
+        Disposer.dispose(rootDisposable)
     }
 }
 


### PR DESCRIPTION
Calling Disposable.dispose() does not dispose other objects that depend on it. Disposer.dispose() must be used to ensure the entire Disposable tree is disposed.