### PR TITLE
Guard against multiple buildscript blocks in a single script

### DIFF
--- a/src/test/kotlin/org/gradle/script/lang/kotlin/integration/GradleScriptKotlinIntegrationTest.kt
+++ b/src/test/kotlin/org/gradle/script/lang/kotlin/integration/GradleScriptKotlinIntegrationTest.kt
@@ -7,6 +7,7 @@ import org.gradle.testkit.runner.GradleRunner
 
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 
 import java.io.File
@@ -15,6 +16,9 @@ class GradleScriptKotlinIntegrationTest {
 
     @JvmField
     @Rule val projectDir = TemporaryFolder()
+
+    @JvmField
+    @Rule val thrown = ExpectedException.none()
 
     @Test
     fun `given a script with SAM conversions, it can run it`() {
@@ -64,6 +68,20 @@ class GradleScriptKotlinIntegrationTest {
 
         assert(
             build("answer").output.contains("*42*"))
+    }
+
+    @Test
+    fun `given multiple buildscript blocks in a single script, parsing will fail with an appropriate error`() {
+        thrown.expectMessage("Only one `buildscript` block is allowed per script")
+
+        withBuildScript("""
+            buildscript {
+            }
+            buildscript {
+            }
+        """)
+
+        build()
     }
 
     private fun withBuildScript(script: String) {


### PR DESCRIPTION
See failing test case. Part of #72.
