### PR TITLE
Kotlin lexer can't process \r symbols

### DIFF
--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildscriptBlockExtraction.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildscriptBlockExtraction.kt
@@ -38,7 +38,7 @@ fun extractBuildscriptBlockFrom(script: String) =
  */
 fun extractTopLevelSectionFrom(script: String, identifier: String): IntRange? =
     KotlinLexer().run {
-        start(script)
+        start(script.replace(Regex.fromLiteral("\r"), ""))
         while (tokenType != null) {
             nextTopLevelSection(identifier)?.let {
                 advance()


### PR DESCRIPTION
There're warning from lexer and errors from Kotlin frontend afterwards 

WARN: org.jetbrains.kotlin.lexer._JetLexer
org.jetbrains.kotlin.lexer.KotlinLexerException: Error: could not match input
 at ''
at org.jetbrains.kotlin.lexer._JetLexer.zzScanError(_JetLexer.java:816)
	at org.jetbrains.kotlin.lexer._JetLexer.advance(_JetLexer.java:1407)
	at org.jetbrains.kotlin.com.intellij.lexer.FlexAdapter.locateToken(FlexAdapter.java:110)
	at org.jetbrains.kotlin.com.intellij.lexer.FlexAdapter.getTokenType(FlexAdapter.java:69)
	at org.gradle.script.lang.kotlin.provider.BuildscriptBlockExtractionKt.findTopLevelIdentifier(BuildscriptBlockExtraction.kt:74)
	at org.gradle.script.lang.kotlin.provider.BuildscriptBlockExtractionKt.nextTopLevelSection(BuildscriptBlockExtraction.kt:56)
	at org.gradle.script.lang.kotlin.provider.BuildscriptBlockExtractionKt.extractTopLevelSectionFrom(BuildscriptBlockExtraction.kt:40)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.extractPluginsBlockFrom(KotlinBuildScriptCompiler.kt:158)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.executePluginsBlockOn(KotlinBuildScriptCompiler.kt:138)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.collectPluginRequestsFromPluginsBlock(KotlinBuildScriptCompiler.kt:133)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.executePluginsBlockOn(KotlinBuildScriptCompiler.kt:127)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.scriptBodyClassLoaderFor(KotlinBuildScriptCompiler.kt:121)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.executeScriptBodyOn(KotlinBuildScriptCompiler.kt:106)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler.access$executeScriptBodyOn(KotlinBuildScriptCompiler.kt:44)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler$compileTopLevelScript$1.invoke(KotlinBuildScriptCompiler.kt:92)
	at org.gradle.script.lang.kotlin.provider.KotlinBuildScriptCompiler$compileTopLevelScript$1.invoke(KotlinBuildScriptCompiler.kt:44)
	at org.gradle.script.lang.kotlin.provider.KotlinScriptPlugin.apply(KotlinScriptPlugin.kt:40)
	at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:39)
	at org.gradle.configuration.project.BuildScriptProcessor.execute(BuildScriptProcessor.java:26)
	at org.gradle.configuration.project.ConfigureActionsProjectEvaluator.evaluate(ConfigureActionsProjectEvaluator.java:34)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.doConfigure(LifecycleProjectEvaluator.java:70)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.access$000(LifecycleProjectEvaluator.java:33)
	at org.gradle.configuration.project.LifecycleProjectEvaluator$1.execute(LifecycleProjectEvaluator.java:53)
	at org.gradle.configuration.project.LifecycleProjectEvaluator$1.execute(LifecycleProjectEvaluator.java:50)
	at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:61)
	at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:50)
	at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:599)
	at org.gradle.api.internal.project.DefaultProject.evaluate(DefaultProject.java:125)
	at org.gradle.execution.TaskPathProjectEvaluator.configure(TaskPathProjectEvaluator.java:35)
	at org.gradle.execution.TaskPathProjectEvaluator.configureHierarchy(TaskPathProjectEvaluator.java:60)
	at org.gradle.configuration.DefaultBuildConfigurer.configure(DefaultBuildConfigurer.java:38)
	at org.gradle.initialization.DefaultGradleLauncher$ConfigureBuildAction.execute(DefaultGradleLauncher.java:231)
	at org.gradle.initialization.DefaultGradleLauncher$ConfigureBuildAction.execute(DefaultGradleLauncher.java:228)
	at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)
	at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:56)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:158)
	at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:119)
	at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:102)
	at org.gradle.launcher.exec.GradleBuildController.run(GradleBuildController.java:71)
	at org.gradle.tooling.internal.provider.ExecuteBuildActionRunner.run(ExecuteBuildActionRunner.java:28)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:41)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:26)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:75)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:49)
	at org.gradle.tooling.internal.provider.ServicesSetupBuildActionExecuter.execute(ServicesSetupBuildActionExecuter.java:44)
	at org.gradle.tooling.internal.provider.ServicesSetupBuildActionExecuter.execute(ServicesSetupBuildActionExecuter.java:29)
	at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:51)
	at org.gradle.internal.Actions$RunnableActionAdapter.execute(Actions.java:173)
	at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:244)
	at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:217)
	at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:33)
	at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:24)
	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:33)
	at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:22)
	at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:210)
	at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:174)
	at org.gradle.launcher.Main.doAction(Main.java:33)
	at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:45)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:60)
	at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:37)
	at org.gradle.launcher.GradleMain.main(GradleMain.java:23)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:30)
	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:108)
	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)