### PR TITLE
Do not fail on non-existing or “empty” script compilation

### DIFF
--- a/samples/multi-kotlin-project-config-injection/build.gradle.kts
+++ b/samples/multi-kotlin-project-config-injection/build.gradle.kts
@@ -16,8 +16,16 @@ allprojects {
     }
 }
 
-// Configure all KotlinCompile tasks on each sub-project
+// Apply and configure the Kotlin Gradle plugin on each sub-project
 subprojects {
+
+    apply {
+        plugin("kotlin")
+    }
+
+    dependencies {
+        compile(kotlinModule("stdlib"))
+    }
 
     tasks.withType<KotlinCompile> {
         println("Configuring $name in project ${project.name}...")

--- a/samples/multi-kotlin-project-config-injection/cli/build.gradle.kts
+++ b/samples/multi-kotlin-project-config-injection/cli/build.gradle.kts
@@ -2,15 +2,10 @@ plugins {
     application
 }
 
-apply {
-    plugin("kotlin")
-}
-
 application {
     mainClassName = "cli.Main"
 }
 
 dependencies {
     compile(project(":core"))
-    compile(kotlinModule("stdlib"))
 }

--- a/samples/multi-kotlin-project-config-injection/core/build.gradle.kts
+++ b/samples/multi-kotlin-project-config-injection/core/build.gradle.kts
@@ -1,7 +1,0 @@
-apply {
-    plugin("kotlin")
-}
-
-dependencies {
-    compile(kotlinModule("stdlib"))
-}

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
@@ -64,7 +64,7 @@ class CachingKotlinCompiler(
         return compileScript(cacheKeyPrefix + scriptFileName + buildscript, classPath, parentClassLoader) { cacheDir ->
             ScriptCompilationSpec(
                 KotlinBuildscriptBlock::class,
-                scriptFile,
+                scriptFile.path,
                 cacheFileFor(buildscript, cacheDir, scriptFileName),
                 scriptFileName + " buildscript block")
         }
@@ -83,7 +83,7 @@ class CachingKotlinCompiler(
         val compiledScript = compileScript(cacheKeyPrefix + scriptFileName + plugins, classPath, parentClassLoader) { cacheDir ->
             ScriptCompilationSpec(
                 KotlinPluginsBlock::class,
-                scriptFile,
+                scriptFile.path,
                 cacheFileFor(plugins, cacheDir, scriptFileName),
                 scriptFileName + " plugins block")
         }
@@ -94,16 +94,17 @@ class CachingKotlinCompiler(
 
     fun compileBuildScript(
         scriptFile: File,
+        script: String,
         additionalSourceFiles: List<File>,
         classPath: ClassPath,
         parentClassLoader: ClassLoader): CompiledScript {
 
         val scriptFileName = scriptFile.name
-        return compileScript(cacheKeyPrefix + scriptFileName + scriptFile, classPath, parentClassLoader) {
+        return compileScript(cacheKeyPrefix + scriptFileName + script, classPath, parentClassLoader) { cacheDir ->
             ScriptCompilationSpec(
                 KotlinBuildScript::class,
-                scriptFile,
-                scriptFile,
+                scriptFile.path,
+                cacheFileFor(script, cacheDir, scriptFileName),
                 scriptFileName,
                 additionalSourceFiles)
         }
@@ -151,7 +152,7 @@ class CachingKotlinCompiler(
 
     data class ScriptCompilationSpec(
         val scriptTemplate: KClass<out Any>,
-        val originalFile: File,
+        val originalFilePath: String,
         val scriptFile: File,
         val description: String,
         val additionalSourceFiles: List<File> = emptyList())
@@ -174,7 +175,7 @@ class CachingKotlinCompiler(
                     classPath.asFiles,
                     parentClassLoader,
                     messageCollectorFor(logger) { path ->
-                        if (path == scriptFile.path) originalFile.path
+                        if (path == scriptFile.path) originalFilePath
                         else path
                     })
             }

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinBuildScriptCompiler.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinBuildScriptCompiler.kt
@@ -59,9 +59,9 @@ class KotlinBuildScriptCompiler(
     val gradleApiExtensions: ClassPath,
     gradleScriptKotlinJars: ClassPath) {
 
-    val scriptResource = scriptSource.resource!!
-    val scriptFile = scriptResource.file!!
-    val script = convertLineSeparators(scriptResource.text!!)
+    val scriptFilePath = scriptSource.fileName!!
+    val scriptFile = File(scriptFilePath)
+    val script = convertLineSeparators(scriptSource.resource!!.text!!)
 
     /**
      * ClassPath inherited from parent projects (including buildSrc)
@@ -193,6 +193,7 @@ class KotlinBuildScriptCompiler(
     private fun compileScriptFile(additionalSourceFiles: List<File>) =
         kotlinCompiler.compileBuildScript(
             scriptFile,
+            script,
             additionalSourceFiles,
             compilationClassPath,
             targetScope.exportClassLoader)
@@ -240,7 +241,7 @@ class KotlinBuildScriptCompiler(
             action()
         } catch (unexpectedBlock: UnexpectedBlock) {
             val (line, column) = script.lineAndColumnFromRange(unexpectedBlock.location)
-            val message = compilerMessageFor(scriptFile.path, line, column, unexpectedBlockMessage(unexpectedBlock))
+            val message = compilerMessageFor(scriptFilePath, line, column, unexpectedBlockMessage(unexpectedBlock))
             throw IllegalStateException(message, unexpectedBlock)
         }
     }


### PR DESCRIPTION
Do not consume ScriptSource TextResource nullable file property.
Rework the multi-kotlin-project-config-injection sample to demonstrate
a subproject with no build script.

See #302