### PR TITLE
Reuse implicit imports provided by Gradle and add Kotlin specifics

### DIFF
--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildServices.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildServices.kt
@@ -22,6 +22,7 @@ import org.gradle.api.internal.cache.GeneratedGradleJarCache
 
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.script.lang.kotlin.cache.ScriptCache
+import org.gradle.script.lang.kotlin.support.ImplicitImports
 
 
 internal
@@ -30,9 +31,10 @@ object BuildServices {
     @Suppress("unused")
     fun createCachingKotlinCompiler(
         scriptCache: ScriptCache,
+        implicitImports: ImplicitImports,
         progressLoggerFactory: ProgressLoggerFactory) =
 
-        CachingKotlinCompiler(scriptCache, progressLoggerFactory)
+        CachingKotlinCompiler(scriptCache, implicitImports, progressLoggerFactory)
 
     @Suppress("unused")
     fun createKotlinScriptClassPathProvider(

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
@@ -45,6 +45,7 @@ import kotlin.reflect.KClass
 internal
 class CachingKotlinCompiler(
     val scriptCache: ScriptCache,
+    val implicitImports: ImplicitImports,
     val progressLoggerFactory: ProgressLoggerFactory) {
 
     private
@@ -190,7 +191,7 @@ class CachingKotlinCompiler(
 
                 object : KotlinScriptExternalDependencies {
                     override val imports: Iterable<String>
-                        get() = ImplicitImports.list
+                        get() = implicitImports.list
                 }
         }
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -19,7 +19,6 @@ package org.gradle.script.lang.kotlin.resolver
 import org.gradle.internal.os.OperatingSystem
 
 import org.gradle.script.lang.kotlin.concurrent.future
-import org.gradle.script.lang.kotlin.support.ImplicitImports
 import org.gradle.script.lang.kotlin.support.userHome
 
 import org.gradle.tooling.ProgressListener
@@ -138,8 +137,8 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
 
         KotlinBuildScriptDependencies(
             response.classPath,
-            ImplicitImports.list,
             response.sourcePath,
+            response.implicitImports,
             hash)
 
     private
@@ -222,8 +221,8 @@ typealias ScriptSectionTokensProvider = (CharSequence, String) -> Sequence<CharS
 internal
 class KotlinBuildScriptDependencies(
     override val classpath: Iterable<File>,
-    override val imports: Iterable<String>,
     override val sources: Iterable<File>,
+    override val imports: Iterable<String>,
     val buildscriptBlockHash: ByteArray?) : KotlinScriptExternalDependencies {
 
     override fun toString(): String = "${super.toString()}(classpath=$classpath, sources=$sources)"

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelBuilder.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelBuilder.kt
@@ -25,6 +25,7 @@ import org.gradle.internal.classpath.DefaultClassPath
 
 import org.gradle.script.lang.kotlin.accessors.accessorsClassPathFor
 import org.gradle.script.lang.kotlin.provider.KotlinScriptClassPathProvider
+import org.gradle.script.lang.kotlin.support.ImplicitImports
 import org.gradle.script.lang.kotlin.support.serviceOf
 
 import org.gradle.tooling.provider.model.ToolingModelBuilder
@@ -36,6 +37,7 @@ import java.io.Serializable
 interface KotlinBuildScriptModel {
     val classPath: List<File>
     val sourcePath: List<File>
+    val implicitImports: List<String>
 }
 
 
@@ -48,7 +50,8 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
     override fun buildAll(modelName: String, project: Project): Any {
         val classPath = scriptClassPathOf(project)
         val sourcePath = sourcePathFor(classPath.bin, project)
-        return StandardKotlinBuildScriptModel(classPath.bin.asFiles, (classPath.src + sourcePath).asFiles)
+        val implicitImports = implicitImportsOf(project)
+        return StandardKotlinBuildScriptModel(classPath.bin.asFiles, (classPath.src + sourcePath).asFiles, implicitImports)
     }
 
     private
@@ -66,6 +69,10 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
                 buildScriptClassPathOf(project)
         }
     }
+
+    private
+    fun implicitImportsOf(project: Project) =
+        project.serviceOf<ImplicitImports>().list
 
     private
     fun sourcePathFor(classPath: ClassPath, project: Project) =
@@ -118,7 +125,8 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
 internal
 data class StandardKotlinBuildScriptModel(
     override val classPath: List<File>,
-    override val sourcePath: List<File>) : KotlinBuildScriptModel, Serializable
+    override val sourcePath: List<File>,
+    override val implicitImports: List<String>) : KotlinBuildScriptModel, Serializable
 
 
 internal

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/services/KotlinScriptServiceRegistry.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/services/KotlinScriptServiceRegistry.kt
@@ -29,10 +29,12 @@ class KotlinScriptServiceRegistry : PluginServiceRegistry {
 
     override fun registerProjectServices(registration: ServiceRegistration) = Unit
 
-    override fun registerGlobalServices(registration: ServiceRegistration?) = Unit
+    override fun registerGlobalServices(registration: ServiceRegistration) {
+        registration.addProvider(org.gradle.script.lang.kotlin.support.GlobalServices)
+    }
 
-    override fun registerBuildSessionServices(registration: ServiceRegistration?) = Unit
+    override fun registerBuildSessionServices(registration: ServiceRegistration) = Unit
 
-    override fun registerGradleServices(registration: ServiceRegistration?) = Unit
+    override fun registerGradleServices(registration: ServiceRegistration) = Unit
 }
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/GlobalServices.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/GlobalServices.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.gradle.script.lang.kotlin.support
 
 import org.gradle.configuration.ImportsReader
 
 
-/**
- * Holds the list of imports implicitly added to every Kotlin build script.
- */
-class ImplicitImports(private val importsReader: ImportsReader) {
+internal
+object GlobalServices {
 
-    val list by lazy {
-        gradleImports() + gradleScriptKotlinImports()
-    }
-
-    private
-    fun gradleImports() = importsReader.importPackages.map { "$it.*" }
-
-    private
-    fun gradleScriptKotlinImports() = listOf("org.gradle.script.lang.kotlin.*", "java.io.File")
+    @Suppress("unused")
+    fun createImplicitImports(importsReader: ImportsReader) =
+        ImplicitImports(importsReader)
 }


### PR DESCRIPTION
Confirmed that it works by removing imports in samples.
Once this is in, we'll be able to remove imports for Gradle public types from our samples and the GSK build script.