### PR TITLE
Tighten exported API

### DIFF
--- a/src/main/kotlin/org/gradle/script/lang/kotlin/cache/BuildServices.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/cache/BuildServices.kt
@@ -22,10 +22,10 @@ import org.gradle.cache.CacheRepository
 import org.gradle.cache.internal.CacheKeyBuilder
 
 
+internal
 object BuildServices {
 
     @Suppress("unused")
-    private
     fun createScriptCache(
         cacheKeyBuilder: CacheKeyBuilder,
         cacheRepository: CacheRepository,

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/cache/ScriptCache.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/cache/ScriptCache.kt
@@ -25,6 +25,7 @@ import org.gradle.cache.internal.CacheKeyBuilder.CacheKeySpec
 import java.io.File
 
 
+internal
 class ScriptCache(
 
     private

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/Either.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/Either.kt
@@ -20,6 +20,7 @@ package org.gradle.script.lang.kotlin.concurrent
 /**
  * Represents values with two possibilities.
  */
+internal
 sealed class Either<out L, out R> {
 
     abstract fun <T> fold(left: (L) -> T, right: (R) -> T): T
@@ -37,12 +38,14 @@ sealed class Either<out L, out R> {
 /**
  * Constructs a [Either.Left] value.
  */
+internal
 fun <L, R> left(value: L): Either<L, R> = Either.Left<L, R>(value)
 
 
 /**
  * Constructs a [Either.Right] value.
  */
+internal
 fun <L, R> right(value: R): Either<L, R> = Either.Right<L, R>(value)
 
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/future.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/future.kt
@@ -32,6 +32,7 @@ import kotlin.coroutines.experimental.startCoroutine
  *
  * The [computation] executes synchronously until its first suspension point.
  */
+internal
 fun <T> future(context: CoroutineContext = EmptyCoroutineContext, computation: suspend () -> T): Future<T> =
     FutureContinuation<T>(context).also { k ->
         computation.startCoroutine(completion = k)

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/tapi.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/concurrent/tapi.kt
@@ -30,13 +30,14 @@ import kotlin.coroutines.experimental.suspendCoroutine
  *
  * Execution will continue on the TAPI executor thread.
  */
-inline
+internal inline
 suspend fun <T> tapi(crossinline computation: (ResultHandler<T>) -> Unit): T =
     suspendCoroutine { k: Continuation<T> ->
         computation(k.asResultHandler())
     }
 
 
+internal
 fun <T> Continuation<T>.asResultHandler(): ResultHandler<T> =
     object : ResultHandler<T> {
         override fun onComplete(result: T) =

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildServices.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildServices.kt
@@ -24,10 +24,10 @@ import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.script.lang.kotlin.cache.ScriptCache
 
 
+internal
 object BuildServices {
 
     @Suppress("unused")
-    private
     fun createCachingKotlinCompiler(
         scriptCache: ScriptCache,
         progressLoggerFactory: ProgressLoggerFactory) =
@@ -35,7 +35,6 @@ object BuildServices {
         CachingKotlinCompiler(scriptCache, progressLoggerFactory)
 
     @Suppress("unused")
-    private
     fun createKotlinScriptClassPathProvider(
         classPathRegistry: ClassPathRegistry,
         dependencyFactory: DependencyFactory,

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildscriptBlockExtraction.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/BuildscriptBlockExtraction.kt
@@ -20,10 +20,12 @@ import org.jetbrains.kotlin.lexer.KotlinLexer
 import org.jetbrains.kotlin.lexer.KtTokens.*
 
 
+internal
 class UnexpectedBlock(val identifier: String, val location: IntRange)
     : RuntimeException("Unexpected block found.")
 
 
+internal
 fun extractBuildscriptBlockFrom(script: String) =
     extractTopLevelSectionFrom(script, "buildscript")
 
@@ -36,6 +38,7 @@ fun extractBuildscriptBlockFrom(script: String) =
  * @return range of found section or null if no top-level section with the given [identifier] could be found
  * @throws UnexpectedBlock if more than one top-level section with the given [identifier] is found
  */
+internal
 fun extractTopLevelSectionFrom(script: String, identifier: String): IntRange? {
     require('\r' !in script) {
         "CR characters are not supported by the Kotlin lexer. Convert the line separators before attempting this operation."

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CachingKotlinCompiler.kt
@@ -42,6 +42,7 @@ import java.io.File
 import kotlin.reflect.KClass
 
 
+internal
 class CachingKotlinCompiler(
     val scriptCache: ScriptCache,
     val progressLoggerFactory: ProgressLoggerFactory) {

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CharSequenceExtensions.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/CharSequenceExtensions.kt
@@ -17,10 +17,12 @@
 package org.gradle.script.lang.kotlin.provider
 
 
+internal
 fun CharSequence.linePreservingSubstring(range: IntRange): String =
     linePreservingSubstring_(range).second
 
 
+internal
 fun CharSequence.linePreservingSubstring_(range: IntRange): Pair<Int, String> {
     val lineCount = take(range.start).count { it == '\n' }
     return lineCount to "\n".repeat(lineCount) + substring(range)
@@ -30,6 +32,7 @@ fun CharSequence.linePreservingSubstring_(range: IntRange): Pair<Int, String> {
 /**
  * Computes the 1-based line and column numbers from the given [range].
  */
+internal
 fun CharSequence.lineAndColumnFromRange(range: IntRange): Pair<Int, Int> {
     require(range.endInclusive <= lastIndex)
     val prefix = take(range.start)

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/ClassLoaderHierarchy.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/ClassLoaderHierarchy.kt
@@ -33,6 +33,7 @@ import java.util.*
 /**
  * A formatter for strings that might contain file system paths.
  */
+internal
 typealias PathStringFormatter = (String) -> String
 
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/JarGenerationProgressMonitorProvider.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/JarGenerationProgressMonitorProvider.kt
@@ -24,10 +24,12 @@ import org.gradle.internal.progress.PercentageProgressFormatter
 
 import java.io.File
 
+internal
 interface JarGenerationProgressMonitorProvider {
     fun progressMonitorFor(outputJar: File, totalWork: Int): ProgressMonitor
 }
 
+internal
 class StandardJarGenerationProgressMonitorProvider(
     val progressLoggerFactory: ProgressLoggerFactory) : JarGenerationProgressMonitorProvider {
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptClassPathProvider.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptClassPathProvider.kt
@@ -36,18 +36,23 @@ import org.gradle.util.GFileUtils.moveFile
 import java.io.File
 
 
+internal
 typealias JarCache = (String, JarGenerator) -> File
 
 
+internal
 typealias JarGenerator = (File) -> Unit
 
 
+private
 typealias JarGeneratorWithProgress = (File, () -> Unit) -> Unit
 
 
+internal
 typealias JarsProvider = () -> Collection<File>
 
 
+internal
 class KotlinScriptClassPathProvider(
     val classPathRegistry: ClassPathRegistry,
     val gradleApiJarsProvider: JarsProvider,
@@ -141,6 +146,7 @@ private
 val gradleApiNotation = DependencyFactory.ClassPathNotation.GRADLE_API
 
 
+private
 fun isKotlinJar(name: String): Boolean =
     name.startsWith("kotlin-stdlib-")
         || name.startsWith("kotlin-reflect-")

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptPluginFactory.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptPluginFactory.kt
@@ -28,7 +28,7 @@ import org.gradle.groovy.scripts.ScriptSource
 
 import org.gradle.plugin.use.internal.PluginRequestApplicator
 
-class KotlinScriptPluginFactory(
+class KotlinScriptPluginFactory internal constructor (
     val classPathProvider: KotlinScriptClassPathProvider,
     val kotlinCompiler: CachingKotlinCompiler,
     val pluginRequestApplicator: PluginRequestApplicator) : ScriptPluginFactory {

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptPluginFactoryProvider.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/provider/KotlinScriptPluginFactoryProvider.kt
@@ -22,7 +22,7 @@ import org.gradle.plugin.use.internal.PluginRequestApplicator
 
 import javax.inject.Inject
 
-class KotlinScriptPluginFactoryProvider @Inject constructor(
+class KotlinScriptPluginFactoryProvider @Inject internal constructor (
     val classPathProvider: KotlinScriptClassPathProvider,
     val kotlinCompiler: CachingKotlinCompiler,
     val pluginRequestApplicator: PluginRequestApplicator) : ScriptPluginFactoryProvider {

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
 
+internal
 typealias Environment = Map<String, Any?>
 
 
@@ -53,7 +54,7 @@ class KotlinBuildScriptDependenciesResolver : ScriptDependenciesResolver {
 
     override fun resolve(
         script: ScriptContents,
-        environment: Environment?,
+        environment: Map<String, Any?>?,
         report: (ScriptDependenciesResolver.ReportSeverity, String, ScriptContents.Position?) -> Unit,
         previousDependencies: KotlinScriptExternalDependencies?) = future {
 
@@ -214,6 +215,7 @@ object ResolverCoordinator {
 }
 
 
+internal
 typealias ScriptSectionTokensProvider = (CharSequence, String) -> Sequence<CharSequence>
 
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelBuilder.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelBuilder.kt
@@ -115,6 +115,7 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
 }
 
 
+internal
 data class StandardKotlinBuildScriptModel(
     override val classPath: List<File>,
     override val sourcePath: List<File>) : KotlinBuildScriptModel, Serializable

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelRequest.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/resolver/KotlinBuildScriptModelRequest.kt
@@ -53,6 +53,7 @@ data class KotlinBuildScriptModelRequest(
     val jvmOptions: List<String> = emptyList())
 
 
+internal
 typealias ModelBuilderCustomization = ModelBuilder<KotlinBuildScriptModel>.() -> Unit
 
 

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/services/KotlinScriptServiceRegistry.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/services/KotlinScriptServiceRegistry.kt
@@ -19,6 +19,7 @@ package org.gradle.script.lang.kotlin.services
 import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.scopes.PluginServiceRegistry
 
+internal
 class KotlinScriptServiceRegistry : PluginServiceRegistry {
 
     override fun registerBuildServices(registration: ServiceRegistration) {

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/ClassPathExtensions.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/ClassPathExtensions.kt
@@ -22,9 +22,11 @@ import org.gradle.internal.classpath.DefaultClassPath
 import java.io.File
 
 
+internal
 fun ClassPath.filter(predicate: (File) -> Boolean): ClassPath =
     DefaultClassPath.of(asFiles.filter(predicate))
 
 
+internal
 operator fun ClassPath.minus(other: ClassPath): ClassPath =
     DefaultClassPath.of(asFiles - other.asFiles)

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/ImplicitImports.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/ImplicitImports.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.script.lang.kotlin.support
 
+internal
 object ImplicitImports {
     val list = listOf(
         "org.gradle.api.*",

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/Maps.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/Maps.kt
@@ -17,12 +17,14 @@
 package org.gradle.script.lang.kotlin.support
 
 
+internal
 fun excludeMapFor(group: String?, module: String?): Map<String, String> =
     mapOfNonNullValuesOf(
         "group" to group,
         "module" to module)
 
 
+internal
 fun mapOfNonNullValuesOf(vararg entries: Pair<String, String?>): Map<String, String> =
     mutableMapOf<String, String>().apply {
         for ((k, v) in entries) {

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/ProgressMonitor.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/ProgressMonitor.kt
@@ -18,6 +18,7 @@ package org.gradle.script.lang.kotlin.support
 
 import java.io.Closeable
 
+internal
 interface ProgressMonitor : Closeable {
     fun onProgress()
 }

--- a/src/main/kotlin/org/gradle/script/lang/kotlin/support/zipTo.kt
+++ b/src/main/kotlin/org/gradle/script/lang/kotlin/support/zipTo.kt
@@ -25,12 +25,14 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
 
+internal
 fun zipTo(zipFile: File, baseDir: File) {
     val files = baseDir.walkTopDown().filter { it.isFile }
     zipTo(zipFile, baseDir, files)
 }
 
 
+internal
 fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
     val entries = files.map { file ->
         val path = file.relativeTo(baseDir).path
@@ -41,11 +43,13 @@ fun zipTo(zipFile: File, baseDir: File, files: Sequence<File>) {
 }
 
 
+internal
 fun zipTo(zipFile: File, entries: Sequence<Pair<String, ByteArray>>) {
     zipTo(zipFile.outputStream(), entries)
 }
 
 
+internal
 fun zipTo(outputStream: OutputStream, entries: Sequence<Pair<String, ByteArray>>) {
     ZipOutputStream(outputStream).use { zos ->
         entries.forEach { entry ->

--- a/src/test/kotlin/org/gradle/script/lang/kotlin/resolver/ResolverCoordinatorTest.kt
+++ b/src/test/kotlin/org/gradle/script/lang/kotlin/resolver/ResolverCoordinatorTest.kt
@@ -56,7 +56,7 @@ class ResolverCoordinatorTest {
     @Test
     fun `given an environment lacking a 'getScriptSectionTokens' entry, it will always try to retrieve the model`() {
 
-        val environment: Environment = emptyMap()
+        val environment = emptyMap<String, Any?>()
         val action1 = resolverActionFor(environment, null)
         withInstanceOf<ResolverAction.RequestNew>(action1) {
             val action2 = resolverActionFor(environment, scriptDependencies())
@@ -65,7 +65,7 @@ class ResolverCoordinatorTest {
     }
 
     private
-    fun resolverActionFor(environment: Environment, previousDependencies: KotlinScriptExternalDependencies?) =
+    fun resolverActionFor(environment: Map<String, Any?>, previousDependencies: KotlinScriptExternalDependencies?) =
         ResolverCoordinator.selectNextActionFor(EmptyScriptContents, environment, previousDependencies)
 
     private
@@ -73,12 +73,12 @@ class ResolverCoordinatorTest {
         KotlinBuildScriptDependencies(emptyList(), emptyList(), emptyList(), buildscriptBlockHash)
 
     private
-    fun environmentWithGetScriptSectionTokensReturning(vararg sections: Pair<String, Sequence<String>>): Environment =
+    fun environmentWithGetScriptSectionTokensReturning(vararg sections: Pair<String, Sequence<String>>) =
         environmentWithGetScriptSectionTokens { _, section -> sections.find { it.first == section }?.second ?: emptySequence() }
 
     private
-    fun environmentWithGetScriptSectionTokens(function: (CharSequence, String) -> Sequence<String>): Environment =
-        mapOf("getScriptSectionTokens" to function)
+    fun environmentWithGetScriptSectionTokens(function: (CharSequence, String) -> Sequence<String>) =
+        mapOf<String, Any?>("getScriptSectionTokens" to function)
 }
 
 private


### PR DESCRIPTION
This commit adds `internal` or `private` to internal members
The only exported API that includes Gradle internals is now in .provider