### PR TITLE
Introduce `kotlin-dsl` plugin

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -29,12 +29,13 @@ test.dependsOn(customInstallation)
 
 data class GradlePlugin(val displayName: String, val id: String, val implementationClass: String)
 
-val plugins =
-    listOf(
-        GradlePlugin(
-            "Embedded Kotlin Gradle Plugin",
-            "org.gradle.kotlin.embedded-kotlin",
-            "org.gradle.script.lang.kotlin.plugins.embedded.EmbeddedKotlinPlugin"))
+val plugins = listOf(
+    GradlePlugin("Embedded Kotlin Gradle Plugin",
+                 "org.gradle.kotlin.embedded-kotlin",
+                 "org.gradle.script.lang.kotlin.plugins.embedded.EmbeddedKotlinPlugin"),
+    GradlePlugin("Gradle Kotlin DSL Plugin",
+                 "org.gradle.kotlin.kotlin-dsl",
+                 "org.gradle.script.lang.kotlin.plugins.dsl.KotlinDslPlugin"))
 
 plugins.forEach { plugin ->
 

--- a/plugins/src/main/kotlin/org/gradle/script/lang/kotlin/plugins/dsl/KotlinDslPlugin.kt
+++ b/plugins/src/main/kotlin/org/gradle/script/lang/kotlin/plugins/dsl/KotlinDslPlugin.kt
@@ -1,0 +1,47 @@
+package org.gradle.script.lang.kotlin.plugins.dsl
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.script.lang.kotlin.gradleScriptKotlinApi
+import org.gradle.script.lang.kotlin.plugins.embedded.EmbeddedKotlinPlugin
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import javax.inject.Inject
+
+/**
+ * The `kotlin-dsl` plugin.
+ */
+open class KotlinDslPlugin @Inject constructor(val moduleRegistry: ModuleRegistry) : Plugin<Project> {
+
+    override fun apply(project: Project) {
+        project.run {
+
+            applyEmbeddedKotlinPlugin()
+            addGradleKotlinDslDependency()
+            configureCompilerPlugins()
+        }
+    }
+
+
+    private
+    fun Project.applyEmbeddedKotlinPlugin() {
+        plugins.apply(EmbeddedKotlinPlugin::class.java)
+    }
+
+
+    private
+    fun Project.addGradleKotlinDslDependency() {
+        dependencies.add("compileOnly", gradleScriptKotlinApi())
+    }
+
+
+    private
+    fun Project.configureCompilerPlugins() {
+        val compilerPluginModule = moduleRegistry.getExternalModule("gradle-script-kotlin-compiler-plugin")
+        val compilerPlugin = compilerPluginModule.classpath.asFiles.first()
+        require(compilerPlugin.exists()) { "Gradle Kotlin DSL Compiler plugin could not be found! " + compilerPlugin }
+        tasks.withType(KotlinCompile::class.java) {
+            it.kotlinOptions.freeCompilerArgs += listOf("-Xplugin", compilerPlugin.path)
+        }
+    }
+}

--- a/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/AbstractPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/AbstractPluginTest.kt
@@ -1,0 +1,15 @@
+package org.gradle.script.lang.kotlin.plugins
+
+import org.gradle.script.lang.kotlin.fixtures.AbstractIntegrationTest
+import org.gradle.script.lang.kotlin.fixtures.gradleRunnerFor
+
+
+open class AbstractPluginTest : AbstractIntegrationTest() {
+
+    protected
+    fun buildWithPlugin(vararg arguments: String) =
+        gradleRunnerFor(projectRoot)
+            .withPluginClasspath()
+            .withArguments(*arguments)
+            .build()!!
+}

--- a/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/dsl/KotlinDslPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/dsl/KotlinDslPluginTest.kt
@@ -1,0 +1,74 @@
+package org.gradle.script.lang.kotlin.plugins.dsl
+
+import org.gradle.script.lang.kotlin.plugins.AbstractPluginTest
+
+import org.gradle.testkit.runner.TaskOutcome
+
+import org.hamcrest.CoreMatchers.equalTo
+
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+
+class KotlinDslPluginTest : AbstractPluginTest() {
+
+    @Test
+    fun `gradle kotlin dsl api dependency is added`() {
+
+        withBuildScript("""
+
+            plugins {
+                `kotlin-dsl`
+            }
+
+        """)
+
+        withFile("src/main/kotlin/code.kt", """
+
+            // src/main/kotlin
+            import org.gradle.script.lang.kotlin.GradleDsl
+
+            // src/generated
+            import org.gradle.script.lang.kotlin.embeddedKotlinVersion
+
+        """)
+
+        val result = buildWithPlugin("classes")
+
+        assertThat(result.task(":compileKotlin").outcome, equalTo(TaskOutcome.SUCCESS))
+    }
+
+    @Test
+    fun `sam-with-receiver kotlin compiler plugin is applied to production code`() {
+
+        withBuildScript("""
+
+            plugins {
+                `kotlin-dsl`
+            }
+
+        """)
+
+        withFile("src/main/kotlin/code.kt", """
+
+            import org.gradle.api.Plugin
+            import org.gradle.api.Project
+
+            class MyPlugin : Plugin<Project> {
+                override fun apply(project: Project) {
+                    project.run {
+                        copy {
+                            from("build.gradle.kts")
+                            into("build/build.gradle.kts.copy")
+                        }
+                    }
+                }
+            }
+
+        """)
+
+        val result = buildWithPlugin("classes")
+
+        assertThat(result.task(":compileKotlin").outcome, equalTo(TaskOutcome.SUCCESS))
+    }
+}

--- a/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/plugins/src/test/kotlin/org/gradle/script/lang/kotlin/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -15,8 +15,8 @@
  */
 package org.gradle.script.lang.kotlin.plugins.embedded
 
-import org.gradle.script.lang.kotlin.fixtures.AbstractIntegrationTest
 import org.gradle.script.lang.kotlin.fixtures.gradleRunnerFor
+import org.gradle.script.lang.kotlin.plugins.AbstractPluginTest
 
 import org.gradle.testkit.runner.TaskOutcome
 
@@ -29,7 +29,7 @@ import org.junit.Test
 import java.io.File
 
 
-class EmbeddedKotlinPluginTest : AbstractIntegrationTest() {
+class EmbeddedKotlinPluginTest : AbstractPluginTest() {
 
     @Test
     fun `applies the kotlin plugin`() {
@@ -42,7 +42,7 @@ class EmbeddedKotlinPluginTest : AbstractIntegrationTest() {
 
         """)
 
-        val result = runWithArguments("assemble")
+        val result = buildWithPlugin("assemble")
 
         assertThat(result.task(":compileKotlin").outcome, equalTo(TaskOutcome.NO_SOURCE))
     }
@@ -65,7 +65,7 @@ class EmbeddedKotlinPluginTest : AbstractIntegrationTest() {
 
         """)
 
-        val result = runWithArguments("help")
+        val result = buildWithPlugin("help")
 
         assertThat(result.output, containsString("Embedded Kotlin Repository"))
         embeddedModules.forEach {
@@ -108,7 +108,7 @@ class EmbeddedKotlinPluginTest : AbstractIntegrationTest() {
 
         """)
 
-        val result = runWithArguments("help")
+        val result = buildWithPlugin("help")
 
         embeddedModules.forEach {
             assertThat(result.output, containsString("${it.name}-${it.version}.jar"))
@@ -139,20 +139,13 @@ class EmbeddedKotlinPluginTest : AbstractIntegrationTest() {
 
         """)
 
-        val result = runWithArguments("dependencies")
+        val result = buildWithPlugin("dependencies")
 
         embeddedModules.forEach {
             assertThat(result.output, containsString("${it.group}:${it.name}:1.1.1 -> ${it.version}"))
             assertThat(result.output, containsString("${it.name}-${it.version}.jar"))
         }
     }
-
-    private
-    fun runWithArguments(vararg arguments: String) =
-        gradleRunnerFor(projectRoot)
-            .withPluginClasspath()
-            .withArguments(*arguments)
-            .build()
 
     private
     fun dependencyDeclarationsFor(modules: List<EmbeddedModule>, version: String? = null) =

--- a/provider/src/main/kotlin/org/gradle/script/lang/kotlin/PluginsAccessors.kt
+++ b/provider/src/main/kotlin/org/gradle/script/lang/kotlin/PluginsAccessors.kt
@@ -30,3 +30,15 @@ import org.gradle.plugin.use.PluginDependencySpec
 inline
 val PluginDependenciesSpec.`embedded-kotlin`: PluginDependencySpec
     get() = id("org.gradle.kotlin.embedded-kotlin") version gradleScriptKotlinVersion
+
+
+/**
+ * The `kotlin-dsl` plugin.
+ *
+ * Fetched from plugin repositories using the following plugin id:
+ * `org.gradle.script.lang.kotlin.plugins.kotlin-dsl`.
+ *
+ * @see org.gradle.script.lang.kotlin.plugins.dsl.KotlinDslPlugin
+ */
+inline val PluginDependenciesSpec.`kotlin-dsl`: PluginDependencySpec
+    get() = id("org.gradle.kotlin.kotlin-dsl") version gradleScriptKotlinVersion

--- a/samples-tests/src/test/kotlin/org/gradle/script/lang/kotlin/samples/CodeQualitySampleTest.kt
+++ b/samples-tests/src/test/kotlin/org/gradle/script/lang/kotlin/samples/CodeQualitySampleTest.kt
@@ -15,18 +15,19 @@ class CodeQualitySampleTest : AbstractSampleTest("code-quality") {
 
         val result = build("build")
 
-        assertThat(result.task(":checkstyleMain").outcome, equalTo(TaskOutcome.SUCCESS))
-        assertThat(result.task(":checkstyleTest").outcome, equalTo(TaskOutcome.SUCCESS))
+        val successfulTasks = listOf(
+            ":checkstyleMain",
+            ":checkstyleTest",
+            ":findbugsMain",
+            ":findbugsTest",
+            ":pmdMain",
+            ":pmdTest",
+            ":jdependMain",
+            ":jdependTest",
+            ":jacocoTestCoverageVerification")
 
-        assertThat(result.task(":findbugsMain").outcome, equalTo(TaskOutcome.SUCCESS))
-        assertThat(result.task(":findbugsTest").outcome, equalTo(TaskOutcome.SUCCESS))
-
-        assertThat(result.task(":pmdMain").outcome, equalTo(TaskOutcome.SUCCESS))
-        assertThat(result.task(":pmdTest").outcome, equalTo(TaskOutcome.SUCCESS))
-
-        assertThat(result.task(":jdependMain").outcome, equalTo(TaskOutcome.SUCCESS))
-        assertThat(result.task(":jdependTest").outcome, equalTo(TaskOutcome.SUCCESS))
-
-        assertThat(result.task(":jacocoTestCoverageVerification").outcome, equalTo(TaskOutcome.SUCCESS))
+        successfulTasks.forEach { taskName ->
+            assertThat(result.task(taskName).outcome, equalTo(TaskOutcome.SUCCESS))
+        }
     }
 }


### PR DESCRIPTION
adds gradleScriptKotlinApi() dependency
applies gsk kotlin compiler plugin to production code